### PR TITLE
Feature/upgrade middleware options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,6 @@
     "no-plusplus": [2, { "allowForLoopAfterthoughts": true }]
   },
   "parserOptions": {
-    "ecmaVersion": 2020
+    "ecmaVersion": 2019
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,5 +11,8 @@
     "import/no-extraneous-dependencies": "off",
     "consistent-return": "off",
     "no-plusplus": [2, { "allowForLoopAfterthoughts": true }]
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
   }
 }

--- a/src/middlewares/__tests__/basicAuthMiddleware.spec.js
+++ b/src/middlewares/__tests__/basicAuthMiddleware.spec.js
@@ -124,12 +124,10 @@ describe('test verifyBasicAuthBeforeHandler error handling', () => {
 });
 
 describe('test verifyBasicAuthBeforeHandler with valid credentials', () => {
-  const validBasicAuth = Buffer.from(
-    generateBasicAuthorizationHash(
-      client.clients.platform_2.key,
-      client.clients.platform_2.secret
-    )
-  ).toString('base64');
+  const validBasicAuth = generateBasicAuthorizationHash(
+    client.clients.platform_2.key,
+    client.clients.platform_2.secret
+  );
 
   test.each`
     clientObj

--- a/src/middlewares/__tests__/basicAuthMiddleware.spec.js
+++ b/src/middlewares/__tests__/basicAuthMiddleware.spec.js
@@ -72,7 +72,10 @@ describe('test verifyBasicAuthBeforeHandler error handling', () => {
       const handler = {
         event: {
           headers,
-          platform,
+          platform: {
+            id: platform,
+            ...client.clients[platform],
+          },
         },
       };
 
@@ -147,7 +150,10 @@ describe('test verifyBasicAuthBeforeHandler with valid credentials', () => {
           headers: {
             Authorization,
           },
-          platform,
+          platform: {
+            id: platform,
+            ...client.clients[platform],
+          },
         },
       };
 
@@ -165,7 +171,10 @@ describe('test verifyBasicAuthBeforeHandler with valid credentials', () => {
 
   test.each`
     siteObjects
-    ${{ platform: 'platform_2' }}
+    ${{ platform: {
+    id: 'platform_2',
+    ...client.clients.platform_2,
+  } }}
     ${{}}
   `('valid site ids', async ({ siteObjects }) => {
     const handler = {

--- a/src/middlewares/__tests__/basicAuthMiddleware.spec.js
+++ b/src/middlewares/__tests__/basicAuthMiddleware.spec.js
@@ -36,24 +36,24 @@ describe('test verifyBasicAuthBeforeHandler error handling', () => {
   ).toString('base64');
 
   test.each`
-    headers                                           | errorName           | errorMessage                                  | errorStatusCode | errorCode                                                               | blacklistMode
+    headers                                           | errorName           | errorMessage                                  | errorStatusCode | errorCode                                                               | platform
     ${{}}                                             | ${'LesgoException'} | ${'Authorization header not found'}           | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTHORIZATION_HEADER_NOT_FOUND'}    | ${undefined}
     ${{ Authorization: 'auth' }}                      | ${'LesgoException'} | ${'Invalid authorization type provided'}      | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_AUTHORIZATION_TYPE'}   | ${undefined}
     ${{ Authorization: 'basic ' }}                    | ${'LesgoException'} | ${'Empty basic authentication hash provided'} | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_EMPTY_BASIC_HASH'}             | ${undefined}
     ${{ Authorization: `basic ${invalidClientKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${undefined}
     ${{ Authorization: `basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${undefined}
     ${{ Authorization: `Basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${undefined}
-    ${{}}                                             | ${'LesgoException'} | ${'Authorization header not found'}           | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTHORIZATION_HEADER_NOT_FOUND'}    | ${true}
-    ${{ Authorization: 'auth' }}                      | ${'LesgoException'} | ${'Invalid authorization type provided'}      | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_AUTHORIZATION_TYPE'}   | ${true}
-    ${{ Authorization: 'basic ' }}                    | ${'LesgoException'} | ${'Empty basic authentication hash provided'} | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_EMPTY_BASIC_HASH'}             | ${true}
-    ${{ Authorization: `basic ${invalidClientKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${true}
-    ${{ Authorization: `basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${true}
-    ${{ Authorization: `Basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${true}
-    ${{ Authorization: 'auth' }}                      | ${'LesgoException'} | ${'Invalid authorization type provided'}      | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_AUTHORIZATION_TYPE'}   | ${false}
-    ${{ Authorization: 'basic ' }}                    | ${'LesgoException'} | ${'Empty basic authentication hash provided'} | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_EMPTY_BASIC_HASH'}             | ${false}
-    ${{ Authorization: `basic ${invalidClientKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${false}
-    ${{ Authorization: `basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${false}
-    ${{ Authorization: `Basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${false}
+    ${{}}                                             | ${'LesgoException'} | ${'Authorization header not found'}           | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTHORIZATION_HEADER_NOT_FOUND'}    | ${'platform_1'}
+    ${{ Authorization: 'auth' }}                      | ${'LesgoException'} | ${'Invalid authorization type provided'}      | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_AUTHORIZATION_TYPE'}   | ${'platform_1'}
+    ${{ Authorization: 'basic ' }}                    | ${'LesgoException'} | ${'Empty basic authentication hash provided'} | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_EMPTY_BASIC_HASH'}             | ${'platform_1'}
+    ${{ Authorization: `basic ${invalidClientKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${'platform_1'}
+    ${{ Authorization: `basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${'platform_1'}
+    ${{ Authorization: `Basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${'platform_1'}
+    ${{ Authorization: 'auth' }}                      | ${'LesgoException'} | ${'Invalid authorization type provided'}      | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_AUTHORIZATION_TYPE'}   | ${'blacklist_platform'}
+    ${{ Authorization: 'basic ' }}                    | ${'LesgoException'} | ${'Empty basic authentication hash provided'} | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_EMPTY_BASIC_HASH'}             | ${'blacklist_platform'}
+    ${{ Authorization: `basic ${invalidClientKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${'blacklist_platform'}
+    ${{ Authorization: `basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${'blacklist_platform'}
+    ${{ Authorization: `Basic ${invalidSecretKey}` }} | ${'LesgoException'} | ${'Invalid client key or secret provided'}    | ${403}          | ${'Middlewares/basicAuthMiddleware::AUTH_INVALID_CLIENT_OR_SECRET_KEY'} | ${'blacklist_platform'}
   `(
     'should throw $errorMessage when authorization header is $headers',
     async ({
@@ -62,23 +62,17 @@ describe('test verifyBasicAuthBeforeHandler error handling', () => {
       errorMessage,
       errorStatusCode,
       errorCode,
-      blacklistMode,
+      platform,
     }) => {
       const handler = {
         event: {
           headers,
-          site: {
-            id: 'platform_1',
-          },
+          platform,
         },
       };
 
       try {
-        expect(
-          verifyBasicAuthBeforeHandler(handler, next, {
-            blacklistMode,
-          })
-        ).toThrow();
+        expect(verifyBasicAuthBeforeHandler(handler, next)).toThrow();
       } catch (error) {
         expect(error.name).toBe(errorName);
         expect(error.message).toBe(errorMessage);
@@ -133,39 +127,32 @@ describe('test verifyBasicAuthBeforeHandler with valid credentials', () => {
   });
 
   test.each`
-    Authorization                | blacklistMode
-    ${undefined}                 | ${false}
-    ${`basic ${validBasicAuth}`} | ${false}
-    ${`Basic ${validBasicAuth}`} | ${false}
-    ${`basic ${validBasicAuth}`} | ${true}
-    ${`Basic ${validBasicAuth}`} | ${true}
-  `(
-    'test Exception with valid credentials',
-    ({ Authorization, blacklistMode }) => {
-      const handler = {
-        event: {
-          headers: {
-            Authorization,
-          },
-          site: {
-            id: 'platform_2',
-          },
+    Authorization                | platform
+    ${undefined}                 | ${'blacklist_platform'}
+    ${`basic ${validBasicAuth}`} | ${'platform_2'}
+    ${`Basic ${validBasicAuth}`} | ${'platform_2'}
+    ${`basic ${validBasicAuth}`} | ${'platform_2'}
+    ${`Basic ${validBasicAuth}`} | ${'platform_2'}
+  `('test Exception with valid credentials', ({ Authorization, platform }) => {
+    const handler = {
+      event: {
+        headers: {
+          Authorization,
         },
-      };
+        platform,
+      },
+    };
 
-      let hasError = false;
+    let hasError = false;
 
-      try {
-        verifyBasicAuthBeforeHandler(handler, next, {
-          blacklistMode,
-        });
-      } catch (e) {
-        hasError = true;
-      }
-
-      expect(hasError).toBeFalsy();
+    try {
+      verifyBasicAuthBeforeHandler(handler, next);
+    } catch (e) {
+      hasError = true;
     }
-  );
+
+    expect(hasError).toBeFalsy();
+  });
 
   test.each`
     siteObjects

--- a/src/middlewares/__tests__/basicAuthMiddleware.spec.js
+++ b/src/middlewares/__tests__/basicAuthMiddleware.spec.js
@@ -11,17 +11,17 @@ describe('test generateBasicAuthorizationHash', () => {
         'e5bb52b012ad4a4e9d862a3410e7013d',
         '4cd19af8f7ca4448bcb2c427754095b5',
         {
-          getAuthHash: key => {
+          getPreHashString: key => {
             return `=${key}=`;
           },
         }
       )
-    ).toBe('=e5bb52b012ad4a4e9d862a3410e7013d=');
+    ).toBe('PWU1YmI1MmIwMTJhZDRhNGU5ZDg2MmEzNDEwZTcwMTNkPQ==');
   });
 
   test('should return basic auth by default', () => {
-    const { getAuthHash } = client;
-    client.getAuthHash = null;
+    const { getPreHashString } = client;
+    client.getPreHashString = null;
 
     expect(
       generateBasicAuthorizationHash(
@@ -32,7 +32,7 @@ describe('test generateBasicAuthorizationHash', () => {
       'ZTViYjUyYjAxMmFkNGE0ZTlkODYyYTM0MTBlNzAxM2Q6NGNkMTlhZjhmN2NhNDQ0OGJjYjJjNDI3NzU0MDk1YjU='
     );
 
-    client.getAuthHash = getAuthHash;
+    client.getPreHashString = getPreHashString;
   });
 });
 

--- a/src/middlewares/__tests__/clientAuthMiddleware.spec.js
+++ b/src/middlewares/__tests__/clientAuthMiddleware.spec.js
@@ -26,7 +26,7 @@ describe('test clientMiddlewareBeforeHandler', () => {
       expect(await clientAuthMiddlewareBeforeHandler(handler, next)).toThrow();
     } catch (error) {
       expect(error.name).toBe('LesgoException');
-      expect(error.message).toBe("Missing required 'x-client-id'");
+      expect(error.message).toBe("Missing required 'clientKey'");
       expect(error.statusCode).toBe(403);
       expect(error.code).toBe(
         'Middlewares/clientAuthMiddleware::INVALID_AUTH_DATA'
@@ -53,6 +53,46 @@ describe('test clientMiddlewareBeforeHandler', () => {
         'Middlewares/clientAuthMiddleware::INVALID_CLIENT_ID'
       );
     }
+  });
+
+  test('should be able to validate from multiple header keys', async () => {
+    const handler = {
+      event: {
+        headers: {
+          'X-Client-Id': '1111-1111-1111-1111',
+        },
+      },
+    };
+
+    let hasError = false;
+
+    try {
+      await clientAuthMiddlewareBeforeHandler(handler, next);
+    } catch (e) {
+      hasError = e;
+    }
+
+    expect(hasError).toBe(false);
+  });
+
+  test('should allow getting from query string parameters', async () => {
+    const handler = {
+      event: {
+        queryStringParameters: {
+          'x-client-id': '1111-1111-1111-1111',
+        },
+      },
+    };
+
+    let hasError = false;
+
+    try {
+      await clientAuthMiddlewareBeforeHandler(handler, next);
+    } catch (e) {
+      hasError = e;
+    }
+
+    expect(hasError).toBe(false);
   });
 
   test('should return success with valid client id', async () => {
@@ -114,7 +154,22 @@ describe('test clientMiddlewareBeforeHandler', () => {
     expect(handler.event).toHaveProperty('created_obj');
   });
 
-  test('should execute passed opt object with callback function', async () => {
+  test('should execute with callback function from config', async () => {
+    const handler = {
+      event: {
+        headers: {},
+        input: {
+          clientid: '1111-1111-1111-1111',
+        },
+      },
+    };
+
+    await clientAuthMiddlewareBeforeHandler(handler, next);
+
+    expect(handler.event).toHaveProperty('created_obj');
+  });
+
+  test('should execute passed opt object with async callback function', async () => {
     const handler = {
       event: {
         headers: {},
@@ -125,13 +180,14 @@ describe('test clientMiddlewareBeforeHandler', () => {
     };
 
     await clientAuthMiddlewareBeforeHandler(handler, next, {
-      callback: h => {
+      callback: async h => {
+        await new Promise(resolve => setTimeout(resolve, 500));
         // eslint-disable-next-line no-param-reassign
-        h.event.created_obj = 'created_obj';
+        h.event.created_obj_async = 'created_obj_async';
       },
     });
 
-    expect(handler.event).toHaveProperty('created_obj');
+    expect(handler.event).toHaveProperty('created_obj_async');
   });
 
   test('should not execute passed opt object with callback function if not a function', async () => {

--- a/src/middlewares/__tests__/clientAuthMiddleware.spec.js
+++ b/src/middlewares/__tests__/clientAuthMiddleware.spec.js
@@ -136,6 +136,32 @@ describe('test clientMiddlewareBeforeHandler', () => {
     expect(hasError).toBe(false);
   });
 
+  test('should set handler.event.platform with valid client id on input', async () => {
+    const handler = {
+      event: {
+        headers: {},
+        input: {
+          clientid: '1111-1111-1111-1111',
+        },
+      },
+    };
+
+    let hasError = false;
+
+    try {
+      await clientAuthMiddlewareBeforeHandler(handler, next);
+    } catch (e) {
+      hasError = true;
+    }
+
+    expect(hasError).toBe(false);
+    expect(handler.event.platform).toStrictEqual({
+      id: 'platform_1',
+      key: '1111-1111-1111-1111',
+      secret: '1111-1111-1111-1111',
+    });
+  });
+
   test('should execute passed callback function', async () => {
     const handler = {
       event: {

--- a/src/middlewares/basicAuthMiddleware.js
+++ b/src/middlewares/basicAuthMiddleware.js
@@ -82,10 +82,12 @@ export const verifyBasicAuthBeforeHandler = async (handler, next, opts) => {
   const { headers, platform } = handler.event;
   const finalClient = getClient(opts);
   const hashFromHeader = getHashFromHeaders(headers);
-  const isAuthOptional =
-    typeof finalClient[platform]?.isAuthOptional?.then === 'function'
-      ? await finalClient[platform].isAuthOptional
-      : finalClient[platform]?.isAuthOptional;
+  let isAuthOptional = finalClient[platform]
+    ? finalClient[platform].isAuthOptional
+    : false;
+  if (isAuthOptional && typeof isAuthOptional.then === 'function') {
+    isAuthOptional = await isAuthOptional;
+  }
 
   if (hashFromHeader) {
     validateBasicAuth(

--- a/src/middlewares/basicAuthMiddleware.js
+++ b/src/middlewares/basicAuthMiddleware.js
@@ -4,15 +4,16 @@ import LesgoException from '../exceptions/LesgoException';
 const FILE = 'Middlewares/basicAuthMiddleware';
 
 export const generateBasicAuthorizationHash = (key, secret, opts = {}) => {
-  const { getAuthHash } = {
+  const { getPreHashString } = {
     ...client,
     ...opts,
   };
-  if (getAuthHash) {
-    return getAuthHash(key, secret);
-  }
+  const preHashString =
+    typeof getPreHashString === 'function'
+      ? getPreHashString(key, secret)
+      : `${key}:${secret}`;
 
-  return Buffer.from(`${key}:${secret}`).toString('base64');
+  return Buffer.from(preHashString).toString('base64');
 };
 
 const getClient = opts => {

--- a/src/middlewares/basicAuthMiddleware.js
+++ b/src/middlewares/basicAuthMiddleware.js
@@ -56,9 +56,7 @@ const getHashFromHeaders = headers => {
     );
   }
 
-  const buff = Buffer.from(authEncoded, 'base64');
-
-  return buff.toString('utf-8');
+  return authEncoded;
 };
 
 const validateBasicAuth = (hash, clientObject, opts, siteId = undefined) => {

--- a/src/middlewares/basicAuthMiddleware.js
+++ b/src/middlewares/basicAuthMiddleware.js
@@ -82,20 +82,13 @@ export const verifyBasicAuthBeforeHandler = async (handler, next, opts) => {
   const { headers, platform } = handler.event;
   const finalClient = getClient(opts);
   const hashFromHeader = getHashFromHeaders(headers);
-  let isAuthOptional = finalClient[platform]
-    ? finalClient[platform].isAuthOptional
-    : false;
+  let isAuthOptional = platform ? platform.isAuthOptional : false;
   if (isAuthOptional && typeof isAuthOptional.then === 'function') {
     isAuthOptional = await isAuthOptional;
   }
 
   if (hashFromHeader) {
-    validateBasicAuth(
-      hashFromHeader,
-      finalClient,
-      opts,
-      handler.event.platform
-    );
+    validateBasicAuth(hashFromHeader, finalClient, opts, platform.id);
   } else if (!platform || !isAuthOptional) {
     /**
      * An error will occur only when either the platform could not be determined, assuming a basic auth is needed.

--- a/src/middlewares/basicAuthMiddleware.js
+++ b/src/middlewares/basicAuthMiddleware.js
@@ -88,7 +88,12 @@ export const verifyBasicAuthBeforeHandler = async (handler, next, opts) => {
   }
 
   if (hashFromHeader) {
-    validateBasicAuth(hashFromHeader, finalClient, opts, platform.id);
+    validateBasicAuth(
+      hashFromHeader,
+      finalClient,
+      opts,
+      platform ? platform.id : undefined
+    );
   } else if (!platform || !isAuthOptional) {
     /**
      * An error will occur only when either the platform could not be determined, assuming a basic auth is needed.

--- a/src/middlewares/basicAuthMiddleware.js
+++ b/src/middlewares/basicAuthMiddleware.js
@@ -1,14 +1,18 @@
 import client from 'Config/client'; // eslint-disable-line import/no-unresolved
-import crypto from 'crypto';
 import LesgoException from '../exceptions/LesgoException';
 
 const FILE = 'Middlewares/basicAuthMiddleware';
 
-export const generateBasicAuthorizationHash = (key, secret) => {
-  return crypto
-    .createHash('sha1')
-    .update(`${key}:${secret}`)
-    .digest('hex');
+export const generateBasicAuthorizationHash = (key, secret, opts = {}) => {
+  const { getAuthHash } = {
+    ...client,
+    ...opts,
+  };
+  if (getAuthHash) {
+    return getAuthHash(key, secret);
+  }
+
+  return Buffer.from(`${key}:${secret}`).toString('base64');
 };
 
 const getClient = opts => {
@@ -62,7 +66,8 @@ const validateBasicAuth = (hash, clientObject, opts, siteId = undefined) => {
     const hashIsEquals =
       generateBasicAuthorizationHash(
         clientObject[clientCode].key,
-        clientObject[clientCode].secret
+        clientObject[clientCode].secret,
+        opts
       ) === hash;
 
     return siteId ? siteId === clientCode && hashIsEquals : hashIsEquals;

--- a/src/middlewares/clientAuthMiddleware.js
+++ b/src/middlewares/clientAuthMiddleware.js
@@ -6,7 +6,7 @@ const FILE = 'Middlewares/clientAuthMiddleware';
 
 const validateParams = params => {
   const validFields = [
-    { key: client.headerKey, type: 'string', required: true },
+    { key: 'clientKey', type: 'string', required: true },
     { key: 'client', type: 'object', required: true },
   ];
 
@@ -20,8 +20,17 @@ const validateParams = params => {
 };
 
 const getClientKey = event => {
-  if (typeof event.headers[client.headerKey] === 'string') {
-    return event.headers[client.headerKey];
+  const foundExistingKey = client.headerKeys.find(
+    headerKey =>
+      typeof event.headers?.[headerKey] === 'string' ||
+      typeof event.queryStringParameters?.[headerKey] === 'string'
+  );
+
+  if (foundExistingKey) {
+    return (
+      event.headers?.[foundExistingKey] ??
+      event.queryStringParameters?.[foundExistingKey]
+    );
   }
 
   if (event.input && typeof event.input.clientid === 'string') {
@@ -31,20 +40,23 @@ const getClientKey = event => {
   return undefined;
 };
 
-export const clientAuthMiddlewareBeforeHandler = (
+export const clientAuthMiddlewareBeforeHandler = async (
   handler,
   next,
-  opt = undefined
+  opt = {}
 ) => {
-  const validated = validateParams({
-    [client.headerKey]: getClientKey(handler.event),
-    client: client.clients,
+  const { clients, callback } = {
+    ...client,
+    ...(typeof opt === 'function' ? { callback: opt } : opt),
+  };
+
+  const { client: validatedClient, clientKey } = validateParams({
+    clientKey: getClientKey(handler.event),
+    client: clients,
   });
 
-  const clientKey = validated[client.headerKey];
-
-  const platform = Object.keys(validated.client).filter(clientPlatform => {
-    return validated.client[clientPlatform].key === clientKey;
+  const platform = Object.keys(validatedClient).filter(clientPlatform => {
+    return validatedClient[clientPlatform].key === clientKey;
   });
 
   if (platform.length === 0) {
@@ -59,11 +71,8 @@ export const clientAuthMiddlewareBeforeHandler = (
   // eslint-disable-next-line no-param-reassign,prefer-destructuring
   handler.event.platform = platform[0];
 
-  if (typeof opt === 'function') {
-    opt(handler);
-  } else if (typeof opt === 'object') {
-    const { callback } = opt;
-    if (typeof callback === 'function') callback(handler);
+  if (typeof callback === 'function') {
+    await callback(handler);
   }
 
   next();

--- a/src/middlewares/clientAuthMiddleware.js
+++ b/src/middlewares/clientAuthMiddleware.js
@@ -80,7 +80,10 @@ export const clientAuthMiddlewareBeforeHandler = async (
   }
 
   // eslint-disable-next-line no-param-reassign,prefer-destructuring
-  handler.event.platform = platform[0];
+  handler.event.platform = {
+    id: platform[0],
+    ...client.clients[platform[0]],
+  };
 
   if (typeof callback === 'function') {
     await callback(handler);

--- a/src/middlewares/clientAuthMiddleware.js
+++ b/src/middlewares/clientAuthMiddleware.js
@@ -20,17 +20,28 @@ const validateParams = params => {
 };
 
 const getClientKey = event => {
-  const foundExistingKey = client.headerKeys.find(
-    headerKey =>
-      typeof event.headers?.[headerKey] === 'string' ||
-      typeof event.queryStringParameters?.[headerKey] === 'string'
-  );
+  const foundExistingKey = client.headerKeys.find(headerKey => {
+    if (event.headers && typeof event.headers[headerKey] === 'string') {
+      return true;
+    }
+
+    if (
+      event.queryStringParameters &&
+      typeof event.queryStringParameters[headerKey] === 'string'
+    ) {
+      return true;
+    }
+
+    return false;
+  });
 
   if (foundExistingKey) {
-    return (
-      event.headers?.[foundExistingKey] ??
-      event.queryStringParameters?.[foundExistingKey]
-    );
+    if (event.headers && event.headers[foundExistingKey]) {
+      return event.headers[foundExistingKey];
+    }
+
+    // There will always be one where this is found existing
+    return event.queryStringParameters[foundExistingKey];
   }
 
   if (event.input && typeof event.input.clientid === 'string') {

--- a/tests/__mocks__/config/client.js
+++ b/tests/__mocks__/config/client.js
@@ -24,18 +24,18 @@ export default {
 
   /*
    *--------------------------------------------------------------------------
-   * Get Basic Auth Hash
+   * Get String Pre-Base64 Hashing
    *--------------------------------------------------------------------------
    *
    * Here you may override how the basic auth hash is derived.
    * Defaults to
    *
    * ````
-   * const getAuthHash = (key, secret) => Buffer.from(`${key}:${secret}`).toString('base64');
+   * const getPreHashString = (key, secret) => `${key}:${secret}`;
    * ````
    *
    */
-  getAuthHash: (key, secret) => {
+  getPreHashString: (key, secret) => {
     return crypto
       .createHash('sha1')
       .update(`${key}:${secret}`)

--- a/tests/__mocks__/config/client.js
+++ b/tests/__mocks__/config/client.js
@@ -6,7 +6,19 @@ export default {
    *
    * Here you may specify what header key to use to pass for client identificaiton.
    */
-  headerKey: 'x-client-id',
+  headerKeys: ['x-client-id', 'X-Client-Id'],
+
+  /*
+   *--------------------------------------------------------------------------
+   * Callback on Success
+   *--------------------------------------------------------------------------
+   *
+   * Here you may call a callback after a successful verification is confirmed
+   */
+  callback: h => {
+    // eslint-disable-next-line no-param-reassign
+    h.event.created_obj = 'created_obj';
+  },
 
   /*
    *--------------------------------------------------------------------------

--- a/tests/__mocks__/config/client.js
+++ b/tests/__mocks__/config/client.js
@@ -32,7 +32,7 @@ export default {
    * `isAuthOptional` boolean or promise property can be passed as well, which skips authentication whenever basic auth is not provided,
    * and only throws an authentication error when a basic auth is provided with incorrect credentials
    *
-   * Other user-defined propoerties can defined as well for access when a match exists
+   * Other user-defined propoerties can defined as well for access when a match exists. These are all set to `handler.event.platform`
    * ```
    * import client from 'Config/client';
    *

--- a/tests/__mocks__/config/client.js
+++ b/tests/__mocks__/config/client.js
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 export default {
   /*
    *--------------------------------------------------------------------------
@@ -18,6 +20,26 @@ export default {
   callback: h => {
     // eslint-disable-next-line no-param-reassign
     h.event.created_obj = 'created_obj';
+  },
+
+  /*
+   *--------------------------------------------------------------------------
+   * Get Basic Auth Hash
+   *--------------------------------------------------------------------------
+   *
+   * Here you may override how the basic auth hash is derived.
+   * Defaults to
+   *
+   * ````
+   * const getAuthHash = (key, secret) => Buffer.from(`${key}:${secret}`).toString('base64');
+   * ````
+   *
+   */
+  getAuthHash: (key, secret) => {
+    return crypto
+      .createHash('sha1')
+      .update(`${key}:${secret}`)
+      .digest('hex');
   },
 
   /*

--- a/tests/__mocks__/config/client.js
+++ b/tests/__mocks__/config/client.js
@@ -28,7 +28,16 @@ export default {
    * Here are each of the clients setup to have access to your application.
    * `key` property is used for external identification, while the key is used for internal.
    * Both `key` and `secret` are used for Basic authentication.
-   * Other user-defined propoerties can defined as well for access under `handler.event.platform`, when a match exists.
+   *
+   * `isAuthOptional` propoerty can be passed as well, which skips authentication whenever basic auth is not provided,
+   * and only throws an authentication error when a basic auth is provided with incorrect credentials
+   *
+   * Other user-defined propoerties can defined as well for access when a match exists
+   * ```
+   * import client from 'Config/client';
+   *
+   * console.log(client[handler.event.platform]);
+   * ```
    */
   clients: {
     platform_1: {
@@ -54,6 +63,10 @@ export default {
     platform_6: {
       key: '6666-6666-6666-6666',
       secret: '6666-6666-6666-6666',
+    },
+    blacklist_platform: {
+      key: '7777-7777-7777-7777',
+      isAuthOptional: true,
     },
   },
 };

--- a/tests/__mocks__/config/client.js
+++ b/tests/__mocks__/config/client.js
@@ -29,7 +29,7 @@ export default {
    * `key` property is used for external identification, while the key is used for internal.
    * Both `key` and `secret` are used for Basic authentication.
    *
-   * `isAuthOptional` propoerty can be passed as well, which skips authentication whenever basic auth is not provided,
+   * `isAuthOptional` boolean or promise property can be passed as well, which skips authentication whenever basic auth is not provided,
    * and only throws an authentication error when a basic auth is provided with incorrect credentials
    *
    * Other user-defined propoerties can defined as well for access when a match exists
@@ -67,6 +67,12 @@ export default {
     blacklist_platform: {
       key: '7777-7777-7777-7777',
       isAuthOptional: true,
+    },
+    blacklist_platform_1: {
+      key: '8888-8888-8888-8888',
+      get isAuthOptional() {
+        return new Promise(resolve => resolve(true));
+      },
     },
   },
 };

--- a/tests/__mocks__/config/client.js
+++ b/tests/__mocks__/config/client.js
@@ -32,7 +32,8 @@ export default {
    * `isAuthOptional` boolean or promise property can be passed as well, which skips authentication whenever basic auth is not provided,
    * and only throws an authentication error when a basic auth is provided with incorrect credentials
    *
-   * Other user-defined propoerties can defined as well for access when a match exists. These are all set to `handler.event.platform`
+   * Other user-defined propoerties can defined as well for access when a match exists. These are all set to `handler.event.platform`.
+   * The Property `id` is appended as well which contains the matched clients key
    * ```
    * import client from 'Config/client';
    *


### PR DESCRIPTION
## CONTEXT
**basicAuthMiddleware** Currently we have a blacklist parameter, but this one is passed as an options and not part of the config so:
- It needs to be specified per client
**authMiddleware** Currently we do not catch multiple casing cases for headers

## CHANGES
- **basicAuthMiddleware** Update the blacklist option so it's available on the config/client.js and make it a callback instead
Add as well an optional blacklist boolean to every site as a force to skip basic auth
- **authMiddleware** Update headers compatibility to instead be an array for flexbility and read from it
Pull as well from query string parameters when exists